### PR TITLE
Feature/fix post meta

### DIFF
--- a/bu-ssl.php
+++ b/bu-ssl.php
@@ -286,11 +286,10 @@ class SSL {
 			$meta_key .= "_$search_type";
 		}
 
-		// Get post meta value.
-		$urls = get_post_meta( $post_id, $meta_key, true );
-
-		// If nothing was returned, search content for insecure urls and update post meta.
-		if ( false === $urls ) {
+		// Get post meta for insecure urls if it exists. Else, search for insecure content and update post meta.
+		if ( metadata_exists( 'post', $post_id, $meta_key ) ) {
+			$urls = get_post_meta( $post_id, $meta_key, true );
+		} else {
 			// Get the post object from the post id.
 			$post = get_post( $post_id );
 

--- a/bu-ssl.php
+++ b/bu-ssl.php
@@ -272,20 +272,38 @@ class SSL {
 		return $urls;
 	}
 
-	public function has_insecure_content( $content = '', $search_type = 'any' ) {
+	/**
+	 * Checks if post has insecure content
+	 *
+	 * @param string $post_id The post ID.
+	 * @param string $search_type The type of html tags to search for. Default is 'any'.
+	 * @return array The array of insecure urls.
+	 */
+	public function has_insecure_content( $post_id, $search_type = 'any' ) {
+		// Get base post_meta_key from options.
 		$meta_key = $this->options['post_meta_key'];
 
+		// If searching for a specific type of tag, append it to the post_meta_key.
 		if ( 'any' !== $search_type ) {
 			$meta_key .= "_$search_type";
 		}
 
+		// Get post meta value.
 		$urls = get_post_meta( $post_id, $meta_key, true );
 
+		// If nothing was returned, search content for insecure urls and update post meta.
 		if ( false === $urls ) {
-			$urls = self::search_for_insecure_content( $content, $search_type );
+			// Get the post object from the post id.
+			$post = get_post( $post_id );
+
+			// Search for insecure content.
+			$urls = self::search_for_insecure_content( $post->post_content, $search_type );
+
+			// Update post meta.
 			self::do_update_postmeta( $meta_key, $post_id, $urls );
 		}
 
+		// Return the insecure urls array.
 		return $urls;
 	}
 

--- a/bu-ssl.php
+++ b/bu-ssl.php
@@ -296,7 +296,6 @@ class SSL {
 			// Search for insecure content.
 			$urls = self::search_for_insecure_content( $post->post_content, $search_type );
 
-			// Update post meta.
 			update_post_meta( $post_id, $meta_key, $urls );
 		}
 

--- a/bu-ssl.php
+++ b/bu-ssl.php
@@ -298,7 +298,7 @@ class SSL {
 			$urls = self::search_for_insecure_content( $post->post_content, $search_type );
 
 			// Update post meta.
-			self::do_update_postmeta( $meta_key, $post_id, $urls );
+			update_post_meta( $post_id, $meta_key, $urls );
 		}
 
 		// Return the insecure urls array.
@@ -354,21 +354,9 @@ class SSL {
 		$urls = self::search_for_insecure_content( $post->post_content );
 
 		// Update post meta with list of insecure urls.
-		self::do_update_postmeta( $this->options['post_meta_key'], $post_id, $urls );
+		update_post_meta( $post_id, $this->options['post_meta_key'], $urls );
 
 		return $urls;
-	}
-
-	/**
-	 * Updates the postmeta
-	 *
-	 * @param string $meta_key The meta key.
-	 * @param int    $post_id The post id.
-	 * @param array  $urls The array of insecure urls.
-	 * @return void
-	 */
-	public function do_update_postmeta( $meta_key, $post_id, $urls ) {
-		update_post_meta( $meta_key, $post_id, $this->options['post_meta_key'], $urls );
 	}
 
 	/**

--- a/bu-ssl.php
+++ b/bu-ssl.php
@@ -224,11 +224,9 @@ class SSL {
 	 * @return void
 	 */
 	public function display_posts_column_ssl_status( $column, $post_id ) {
-		global $post;
-
 		if ( 'bu-ssl' === $column ) {
 			// Check if the post has insecure content and display appropriate icon.
-			echo count( self::has_insecure_content( $post->post_content ) ) ? '&#10071;' : '&#9989;';
+			echo count( self::has_insecure_content( $post_id ) ) ? '&#10071;' : '&#9989;';
 		}
 	}
 
@@ -324,7 +322,7 @@ class SSL {
 			$camo->setCamoKey( BU_SSL_CAMO_KEY );
 
 			// Get list of insecure img urls.
-			$urls = self::has_insecure_content( $content, 'img' );
+			$urls = self::has_insecure_content( $post->ID, 'img' );
 
 			if ( ! empty( $urls ) ) {
 				// Create a proxy url and replace the insecure url with it.
@@ -380,7 +378,7 @@ class SSL {
 	 */
 	public function maybe_editor_warning() {
 		global $post;
-		if ( count( self::has_insecure_content( $post->post_content ) ) ) {
+		if ( count( self::has_insecure_content( $post->ID ) ) ) {
 			$message = __( '&#x1F513; This post contains content loaded over an insecure connection.' );
 			// $message .= __( ' These images will be filtered through a <a href="#">secure image proxy</a>.' );
 			printf(


### PR DESCRIPTION
The plugin was using the incorrect parameter signature for `update_post_meta` in `do_update_postmeta`. After fixing it I noticed that the `do_update_postmeta` became nothing more than a useless wrapper around `update_post_meta` so I removed it and updated the code to use `update_post_meta` directly.

I also updated the post meta logic inside `has_insecure_content` since it was checking if `$urls` was false but `get_post_meta` actually returns an empty string when the post meta doesn't exist. To be even more safe I changed it to use the `metadata_exists` function.
